### PR TITLE
Removed prometheus-app direct relation in test, unpinned black version

### DIFF
--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -59,7 +59,6 @@ async def test_prometheus_grafana_integration(ops_test: OpsTest):
     await ops_test.model.deploy(grafana, channel="latest/beta")
     await ops_test.model.add_relation(prometheus, grafana)
     await ops_test.model.add_relation(APP_NAME, grafana)
-    await ops_test.model.add_relation(prometheus, APP_NAME)
     await ops_test.model.deploy(
         prometheus_scrape_charm,
         channel="latest/beta",

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ deps =
 deps =
     flake8
     flake8-copyright<0.3
-    black==20.8b1
+    black
 commands =
     flake8 {toxinidir}/src {toxinidir}/tests
     black --check {toxinidir}/src {toxinidir}/tests


### PR DESCRIPTION
- Update of https://github.com/canonical/metacontroller-operator/pull/6 according to latest Observability Team's review: removed the direct relation between prometheus and metacontroller-operator.
- Unpinned `black==20.8b1` version