### PR TITLE
test release charm action

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -20,8 +20,8 @@ jobs:
     if: (github.event_name == 'push') ||  (startsWith( github.head_ref, 'branch/' ))
     steps:
       - uses: actions/checkout@v2
-      - uses: canonical/charmhub-upload-action@0.2.0
+      - uses: canonical/charming-actions/upload-charm@1.0.0
         with:
           credentials: ${{ secrets.CHARMCRAFT_CREDENTIALS }}
-          charm-path: ./
-          charmcraft-channel: latest/edge
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          channel: latest/edge

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,29 @@
+name: Release charm to other tracks and channels
+
+on:
+  workflow_dispatch:
+    inputs:
+      destination-channel:
+        description: 'Destination Channel'
+        required: true
+      origin-channel:
+        description: 'Origin Channel'
+        required: false
+      rev:
+        description: 'Revision number'
+        required: false
+
+jobs:
+  promote-charm:
+    name: Promote charm
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Release charm to channel
+        uses: canonical/charming-actions/release-charm@promote-charm
+        with:
+          credentials: ${{ secrets.CHARMCRAFT_CREDENTIALS }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          destination-channel: ${{ github.event.inputs.destination-channel }}
+          origin-channel: ${{ github.event.inputs.origin-channel }}
+          revision: ${{ github.event.inputs.rev }}

--- a/src/charm.py
+++ b/src/charm.py
@@ -47,9 +47,7 @@ class MetacontrollerOperatorCharm(CharmBase):
             jobs=[
                 {
                     "metrics_path": METRICS_PATH,
-                    "static_configs": [
-                        {"targets": ["*:{}".format(METRICS_PORT)]}
-                    ],
+                    "static_configs": [{"targets": ["*:{}".format(METRICS_PORT)]}],
                 }
             ],
         )

--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,7 @@ deps =
     black
 commands =
     flake8 {toxinidir}/src {toxinidir}/tests
-    black --check {toxinidir}/src {toxinidir}/tests
+    black --check --diff {toxinidir}/src {toxinidir}/tests
 
 [testenv:unit]
 commands =


### PR DESCRIPTION
Add new release charm action and some lint fixes. Update publish action to use `upload-charm` as the release action need the release info from that action. 
It's using the release charm action from [promote-charm branch](https://github.com/canonical/charming-actions/tree/promote-charm). This would be updated in the future to use stable version