### PR TITLE
refactor: change unit tests so they don't break on version bumps

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -26,7 +26,6 @@ from tenacity import (
 )
 
 
-METACONTROLLER_IMAGE = "metacontroller/metacontroller:v0.3.0"
 METRICS_PATH = "/metrics"
 METRICS_PORT = "9999"
 
@@ -61,7 +60,7 @@ class MetacontrollerOperatorCharm(CharmBase):
 
         self._name: str = self.model.app.name
         self._namespace: str = self.model.name
-        self._metacontroller_image: str = METACONTROLLER_IMAGE
+        self._metacontroller_image = "metacontroller/metacontroller:v0.3.0"
         self._resource_files: dict = {
             "crds": "metacontroller-crds-v1.yaml",
             "rbac": "metacontroller-rbac.yaml",

--- a/tests/unit/render_resource/simple_manifest_result.yaml
+++ b/tests/unit/render_resource/simple_manifest_result.yaml
@@ -7,7 +7,7 @@ spec:
   template:
     spec:
       containers:
-      - image: metacontroller/metacontroller:v0.3.0
+      - image: sample/metacontroller:tag
         name: metacontroller
 ---
 apiVersion: v1

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -44,6 +44,7 @@ def test_render_resource(harness_with_charm):
     harness = harness_with_charm
     harness.charm._manifest_file_root = manifest_root
     harness.charm._resource_files = {"test_yaml": unrendered_yaml_file}
+    harness.charm._metacontroller_image = "sample/metacontroller:tag"
 
     assert harness.charm._manifest_file_root == Path(manifest_root)
 


### PR DESCRIPTION
This change should not change any function, but will mean we don't need to edit tests every time we bump the image version

merge after #18