### PR TITLE
feat: move prometheus/grafana integration test to chisme

### DIFF
--- a/test-integration-requirements.txt
+++ b/test-integration-requirements.txt
@@ -1,1 +1,3 @@
 pytest-operator
+# Temporarily pin to branch for demo purposes
+git+https://github.com/canonical/charmed-kubeflow-chisme.git@demo-shared-tests

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -1,13 +1,12 @@
 # Copyright 2021 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-import json
 import logging
 from pathlib import Path
 import pytest
-import requests
 import yaml
 
+from charmed_kubeflow_chisme.testing import prometheus_grafana_integration_test
 from pytest_operator.plugin import OpsTest
 
 logger = logging.getLogger(__name__)
@@ -50,45 +49,7 @@ async def test_build_and_deploy_with_trust(ops_test: OpsTest):
 
 async def test_prometheus_grafana_integration(ops_test: OpsTest):
     """Deploy prometheus, grafana and required relations, then test the metrics."""
-    prometheus = "prometheus-k8s"
-    grafana = "grafana-k8s"
-    prometheus_scrape_charm = "prometheus-scrape-config-k8s"
-    scrape_config = {"scrape_interval": "30s"}
-
-    await ops_test.model.deploy(prometheus, channel="latest/beta", trust=True)
-    await ops_test.model.deploy(grafana, channel="latest/beta", trust=True)
-    await ops_test.model.add_relation(
-        f"{prometheus}:grafana-dashboard", f"{grafana}:grafana-dashboard"
-    )
-    await ops_test.model.add_relation(
-        f"{APP_NAME}:grafana-dashboard", f"{grafana}:grafana-dashboard"
-    )
-    await ops_test.model.deploy(
-        prometheus_scrape_charm,
-        channel="latest/beta",
-        config=scrape_config)
-    await ops_test.model.add_relation(APP_NAME, prometheus_scrape_charm)
-    await ops_test.model.add_relation(
-        f"{prometheus}:metrics-endpoint", f"{prometheus_scrape_charm}:metrics-endpoint"
-    )
-    await ops_test.model.wait_for_idle(status="active", timeout=60 * 10)
-
-    status = await ops_test.model.get_status()
-    prometheus_unit_ip = status["applications"][prometheus]["units"][f"{prometheus}/0"][
-        "address"
-    ]
-    logger.info(f"Prometheus available at http://{prometheus_unit_ip}:9090")
-
-    r = requests.get(
-        f'http://{prometheus_unit_ip}:9090/api/v1/query?query=up{{juju_application="{APP_NAME}"}}'
-    )
-    response = json.loads(r.content.decode("utf-8"))
-    response_status = response["status"]
-    logger.info(f"Response status is {response_status}")
-
-    response_metric = response["data"]["result"][0]["metric"]
-    assert response_metric["juju_application"] == APP_NAME
-    assert response_metric["juju_model"] == ops_test.model_name
+    await prometheus_grafana_integration_test(APP_NAME, ops_test)
 
 
 # TODO: Add test for charm removal


### PR DESCRIPTION
This is an example of how we could put some of our shared test code in chisme to reduce duplication.  See also canonical/charmed-kubeflow-chisme#21