### PR TITLE
update microk8s version

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -54,7 +54,7 @@ jobs:
       uses: charmed-kubernetes/actions-operator@main
       with:
         provider: microk8s
-        channel: 1.21/stable
+        channel: 1.22/stable
         charmcraft-channel: latest/candidate
 
     - name: Test


### PR DESCRIPTION
Update ci to use microk8s 1.22/stable
ci fails because of slashes in branch name when publishing charm. Tests passed.