### PR TITLE
ci: k8s version bump 1.2x -> 1.24

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -54,7 +54,7 @@ jobs:
       uses: claudiubelu/actions-operator@18ebf92ae3043bd3dd15238e5d9b662d7ba08daf
       with:
         provider: microk8s
-        channel: 1.22/stable
+        channel: 1.24/stable
         # Pinned until this bug is resolved: https://bugs.launchpad.net/juju/+bug/1992833
         bootstrap-options: "--agent-version=2.9.34"
         microk8s-addons: "dns storage rbac metallb:10.64.140.43-10.64.140.49"


### PR DESCRIPTION
[skip ci] ci: k8s version bump 1.2x -> 1.24