### PR TITLE
Upgrade metacontroller to v3.0.0

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -52,7 +52,7 @@ class MetacontrollerOperatorCharm(CharmBase):
 
         self._name: str = self.model.app.name
         self._namespace: str = self.model.name
-        self._metacontroller_image = "docker.io/metacontrollerio/metacontroller:v2.0.4"
+        self._metacontroller_image = "docker.io/metacontrollerio/metacontroller:v3.0.0"
         self._resource_files: dict = {
             "crds": "metacontroller-crds-v1.yaml",
             "rbac": "metacontroller-rbac.yaml",


### PR DESCRIPTION
Upgrade metacontroller to v3.0.0. There are no other changes in the yaml files (based on comparison with this https://github.com/metacontroller/metacontroller/releases/tag/v3.0.0).