### PR TITLE
fix: Make the metacontroller image configurable

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,5 @@
+options:
+  metacontroller-image:
+    type: string
+    default: docker.io/metacontrollerio/metacontroller:v3.0.0
+    description: Metacontroller image

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -7,11 +7,6 @@ description: |
 assumes:
   - juju >= 2.9
 summary: An add-on for Kubernetes to write and deploy custom controllers from simple scripts
-resources:
-  oci-image:
-    type: oci-image
-    description: OCI image for metacontroller
-    upstream-source: docker.io/metacontrollerio/metacontroller:v3.0.0
 provides:
   metrics-endpoint:
     interface: prometheus_scrape

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -29,14 +29,6 @@ def harness():
 def harness_with_charm(harness):
     harness.set_leader(True)
     harness.set_model_name("test-namespace")
-    harness.add_oci_resource(
-        "oci-image",
-        {
-            "registrypath": "image",
-            "username": "",
-            "password": "",
-        },
-    )
     harness.begin()
     return harness
 

--- a/tools/get-images.sh
+++ b/tools/get-images.sh
@@ -4,6 +4,6 @@
 #
 # dynamic list
 IMAGE_LIST=()
-IMAGE_LIST+=($(find -type f -name metadata.yaml -exec yq '.resources | to_entries | .[] | .value | ."upstream-source"' {} \;))
+IMAGE_LIST+=($(find -type f -name config.yaml -exec yq eval .options.metacontroller-image.default {} \;))
 printf "%s\n" "${IMAGE_LIST[@]}"
 


### PR DESCRIPTION
Expose the metacontroller image in config.yaml, so that it can be set either pre or post deployment. This also ensures that the image is always pulled from the specified source and not a private registry, which the metacontroller StatefulSet doesn't have permission to access.

Refs #80 