### PR TITLE
fix: Downgrade metacontroller to v2.0.4

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,5 +1,5 @@
 options:
   metacontroller-image:
     type: string
-    default: docker.io/metacontrollerio/metacontroller:v3.0.0
+    default: docker.io/metacontrollerio/metacontroller:v2.0.4
     description: Metacontroller image


### PR DESCRIPTION
Downgrade the metacontroller image to be in-sync with upstream and avoid issues caused due to the latest version of the CompositeController not supporting watching for namespaces.

Closes https://github.com/canonical/metacontroller-operator/issues/84
Refs https://github.com/canonical/kfp-operators/issues/314