### PR TITLE
backport(fix): Pin Prometheus and Grafana revisions (#82)

### DIFF
--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -57,8 +57,28 @@ async def test_prometheus_grafana_integration(ops_test: OpsTest):
     scrape_config = {"scrape_interval": "30s"}
 
     # Deploy and relate prometheus
-    await ops_test.model.deploy(prometheus, channel="latest/edge", trust=True)
-    await ops_test.model.deploy(grafana, channel="latest/edge", trust=True)
+    # FIXME: Unpin revision once https://github.com/canonical/bundle-kubeflow/issues/688 is closed
+    await ops_test.juju(
+        "deploy",
+        prometheus,
+        "--channel",
+        "latest/edge",
+        "--revision",
+        "137",
+        "--trust",
+        check=True,
+    )
+    # FIXME: Unpin revision once https://github.com/canonical/bundle-kubeflow/issues/690 is closed
+    await ops_test.juju(
+        "deploy",
+        grafana,
+        "--channel",
+        "latest/edge",
+        "--revision",
+        "89",
+        "--trust",
+        check=True,
+    )
     await ops_test.model.deploy(prometheus_scrape, channel="latest/beta", config=scrape_config)
 
     await ops_test.model.add_relation(APP_NAME, prometheus_scrape)


### PR DESCRIPTION
This PR backports #82 needed for integration tests to succeed.
Refs https://github.com/canonical/bundle-kubeflow/issues/688
Refs https://github.com/canonical/bundle-kubeflow/issues/690