### PR TITLE
Update image to v3.0.0

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,5 +1,5 @@
 options:
   metacontroller-image:
     type: string
-    default: docker.io/metacontrollerio/metacontroller:v2.0.4
+    default: docker.io/metacontrollerio/metacontroller:v3.0.0
     description: Metacontroller image


### PR DESCRIPTION
To use decorator contoller in kfp-profiles-controller https://github.com/canonical/kfp-operators/pull/344 we need metacontroller v3. 