### PR TITLE
fix: update config with reference to rock

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,5 +1,5 @@
 options:
   metacontroller-image:
     type: string
-    default: docker.io/metacontrollerio/metacontroller:v3.0.0
+    default: charmedkubeflow/metacontroller:2.0.4_22.04_1
     description: Metacontroller image

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -57,28 +57,8 @@ async def test_prometheus_grafana_integration(ops_test: OpsTest):
     scrape_config = {"scrape_interval": "30s"}
 
     # Deploy and relate prometheus
-    # FIXME: Unpin revision once https://github.com/canonical/bundle-kubeflow/issues/688 is closed
-    await ops_test.juju(
-        "deploy",
-        prometheus,
-        "--channel",
-        "latest/edge",
-        "--revision",
-        "137",
-        "--trust",
-        check=True,
-    )
-    # FIXME: Unpin revision once https://github.com/canonical/bundle-kubeflow/issues/690 is closed
-    await ops_test.juju(
-        "deploy",
-        grafana,
-        "--channel",
-        "latest/edge",
-        "--revision",
-        "89",
-        "--trust",
-        check=True,
-    )
+    await ops_test.model.deploy(prometheus, channel="latest/edge", trust=True)
+    await ops_test.model.deploy(grafana, channel="latest/edge", trust=True)
     await ops_test.model.deploy(prometheus_scrape, channel="latest/beta", config=scrape_config)
 
     await ops_test.model.add_relation(APP_NAME, prometheus_scrape)


### PR DESCRIPTION
# Description

Referencing ROCK in config for the charm.
Reverted back deployment of prometheus and grafana