### PR TITLE
fix: create a Service for the workload and fix the metrics collector

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -69,7 +69,6 @@ class MetacontrollerOperatorCharm(CharmBase):
         self.framework.observe(self.on.config_changed, self._install)
         self.framework.observe(self.on.update_status, self._update_status)
 
-
     def _install(self, event):
         """Creates k8s resources required for the charm, patching over any existing ones it finds"""
         self.logger.info("Installing by instantiating Kubernetes objects")

--- a/src/charm.py
+++ b/src/charm.py
@@ -94,8 +94,8 @@ class MetacontrollerOperatorCharm(CharmBase):
                 raise e
 
         self._create_resource("crds")
-
         self._create_resource("controller")
+        self._create_resource("service")
 
         self.logger.info("Waiting for installed Kubernetes objects to be operational")
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -32,7 +32,6 @@ class MetacontrollerOperatorCharm(CharmBase):
             self.model.unit.status = WaitingStatus("Waiting for leadership")
             return
 
-
         self.framework.observe(self.on.install, self._install)
         self.framework.observe(self.on.config_changed, self._install)
         self.framework.observe(self.on.update_status, self._update_status)
@@ -63,7 +62,6 @@ class MetacontrollerOperatorCharm(CharmBase):
                 }
             ],
         )
-
 
         # TODO: Fix file imports and move ./src/files back to ./files
         self._manifest_file_root: Path = Path("./src/files/manifests/")

--- a/src/files/manifests/metacontroller-svc.yaml
+++ b/src/files/manifests/metacontroller-svc.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: Service
 metadata:

--- a/src/files/manifests/metacontroller-svc.yaml
+++ b/src/files/manifests/metacontroller-svc.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ app_name }}-svc
+  namespace: {{ namespace }}
+spec:
+  ports:
+  - name: metrics-endpoint
+    port: {{ metrics_port }}
+    protocol: TCP
+    targetPort: {{ metrics_port }}
+  selector:
+    # This selector ensures this Service identifies
+    # the metacontroller workload Pod correctly as ti will have
+    # the same tag. Please NOTE this is pointing at the workload
+    # and not the charm. The label is assigned to the Pod via the
+    # StatefulSet located in the same directory as this file.
+    app.kubernetes.io/name: {{ namespace }}-{{ app_name }}-charm
+

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -117,8 +117,10 @@ async def test_prometheus_grafana_integration(ops_test: OpsTest):
             assert response_metric["juju_model"] == ops_test.model_name
 
             # Assert the unit is available by checking the query result
+            # The data is presented as a list [1707357912.349, '1'], where the
+            # first value is a timestamp and the second value is the state of the unit
             # 1 means available, 0 means unavailable
-            assert response["data"]["result"][0]["value"] == "1"
+            assert response["data"]["result"][0]["value"][1] == "1"
 
 
 # Helper to retry calling a function over 30 seconds or 5 attempts

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -116,6 +116,10 @@ async def test_prometheus_grafana_integration(ops_test: OpsTest):
             assert response_metric["juju_application"] == APP_NAME
             assert response_metric["juju_model"] == ops_test.model_name
 
+            # Assert the unit is available by checking the query result
+            # 1 means available, 0 means unavailable
+            assert response["data"]["result"][0]["value"] == "1"
+
 
 # Helper to retry calling a function over 30 seconds or 5 attempts
 retry_for_5_attempts = tenacity.Retrying(


### PR DESCRIPTION
This charm was not deploying any Service for the workload container, which is fine for its regular functions, but causes an issue when the Prometheus scraper tries reaching out the metrics endpoint. This commit adds a Service that is attached to the WORKLOAD (the container inside the Pod that gets created by the [StatefulSet](https://github.com/canonical/metacontroller-operator/blob/main/src/files/manifests/metacontroller.yaml) we are applying manually) so that its metrics can be reached correctly. 

Because of the above, the MetricsEndpointProvider's target has to be refactored to point to the correct service. In a previous version of this charm, the target was pointing to the charm's container, which does not have any metrics endpoit, causing the issues reported in canonical/bundle-kubeflow#564.

Part of canonical/bundle-kubeflow#564

#### Testing
Please refer to the steps to reproduce in [this comment](https://github.com/canonical/bundle-kubeflow/issues/564#issuecomment-1925538870), just deploying this app. After deploying this app and cos-lite, relations and dependencies, and waiting a couple minutes (10 min) none of the alerts should fire (for this app only).

#### TODO
- [x] refactor integration `test case test_prometheus_grafana_integration`
- [ ] create a backport PR for `track/ckf-1.8`