### PR TITLE
feat: use metacontroller rock v3.0.0

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,5 +1,5 @@
 options:
   metacontroller-image:
     type: string
-    default: docker.io/metacontrollerio/metacontroller:v3.0.0
+    default: charmedkubeflow/metacontroller:3.0.0-0ac1edc
     description: Metacontroller image


### PR DESCRIPTION
integrates metacontroller rock `v3.0.0` in the charm, built from the `On Push` of PR https://github.com/canonical/metacontroller-rock/pull/10