### PR TITLE
Add `PodDefault` gate before deploying metacontroller.

### DIFF
--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -5,7 +5,7 @@ import logging
 from contextlib import nullcontext as does_not_raise
 from pathlib import Path
 from unittest import mock
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import lightkube.codecs
 import pytest


### PR DESCRIPTION
Please read the issue before approving: https://github.com/canonical/bundle-kubeflow/issues/951

This solution will put metacontroller to blocked state if PodDefaults are not present. When they are deployed this solution relies on `update-status` event to unblock the charm. Added also integration test to simulate the situation.