### PR TITLE
fix(terraform): Set default value to `metacontroller-operator`

### DIFF
--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,7 +1,7 @@
 variable "app_name" {
   description = "Application name"
   type        = string
-  default     = "training-operator"
+  default     = "metacontroller-operator"
 }
 
 variable "channel" {


### PR DESCRIPTION
There's a "typo" in the `variables.tf` where app_name defaults to `training-operator`.