### PR TITLE
Update manifests for 1.10-rc.0

### DIFF
--- a/src/files/manifests/metacontroller-crds-v1.yaml
+++ b/src/files/manifests/metacontroller-crds-v1.yaml
@@ -1,4 +1,3 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/src/files/manifests/metacontroller-svc.yaml
+++ b/src/files/manifests/metacontroller-svc.yaml
@@ -12,7 +12,7 @@ spec:
     targetPort: {{ metrics_port }}
   selector:
     # This selector ensures this Service identifies
-    # the metacontroller workload Pod correctly as ti will have
+    # the metacontroller workload Pod correctly as it will have
     # the same tag. Please NOTE this is pointing at the workload
     # and not the charm. The label is assigned to the Pod via the
     # StatefulSet located in the same directory as this file.


### PR DESCRIPTION
For reference, the upstream manifests are located [here](https://github.com/kubeflow/manifests/tree/0259e7ba489672bb1cad4a6dd3227b71a498c95c/apps/pipeline/upstream/third-party/metacontroller/base).

Note that the new manifests have an added `securityContext` field, which I am not including, see the [track issue](https://github.com/canonical/kfp-operators/issues/675).