### PR TITLE
chore: update metacontroller manifests to v1.10.0-rc.2

### DIFF
--- a/src/files/manifests/metacontroller-crds-v1.yaml
+++ b/src/files/manifests/metacontroller-crds-v1.yaml
@@ -22,6 +22,7 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
+        description: CompositeController
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
@@ -43,6 +44,12 @@ spec:
                     updateStrategy:
                       properties:
                         method:
+                          enum:
+                          - OnDelete
+                          - Recreate
+                          - InPlace
+                          - RollingRecreate
+                          - RollingInPlace
                           type: string
                         statusChecks:
                           properties:
@@ -72,9 +79,34 @@ spec:
                 properties:
                   customize:
                     properties:
+                      version:
+                        default: v1
+                        enum:
+                        - v1
+                        - v2
+                        type: string
                       webhook:
                         properties:
+                          etag:
+                            properties:
+                              cacheCleanupSeconds:
+                                format: int32
+                                type: integer
+                              cacheTimeoutSeconds:
+                                format: int32
+                                type: integer
+                              enabled:
+                                type: boolean
+                            type: object
                           path:
+                            type: string
+                          responseUnMarshallMode:
+                            description: Sets the json unmarshall mode. One of the
+                              'loose' or 'strict'. In 'strict' mode additional checks
+                              are performed to detect unknown and duplicated fields.
+                            enum:
+                            - loose
+                            - strict
                             type: string
                           service:
                             properties:
@@ -92,6 +124,7 @@ spec:
                             - namespace
                             type: object
                           timeout:
+                            format: duration
                             type: string
                           url:
                             type: string
@@ -99,9 +132,34 @@ spec:
                     type: object
                   finalize:
                     properties:
+                      version:
+                        default: v1
+                        enum:
+                        - v1
+                        - v2
+                        type: string
                       webhook:
                         properties:
+                          etag:
+                            properties:
+                              cacheCleanupSeconds:
+                                format: int32
+                                type: integer
+                              cacheTimeoutSeconds:
+                                format: int32
+                                type: integer
+                              enabled:
+                                type: boolean
+                            type: object
                           path:
+                            type: string
+                          responseUnMarshallMode:
+                            description: Sets the json unmarshall mode. One of the
+                              'loose' or 'strict'. In 'strict' mode additional checks
+                              are performed to detect unknown and duplicated fields.
+                            enum:
+                            - loose
+                            - strict
                             type: string
                           service:
                             properties:
@@ -119,6 +177,7 @@ spec:
                             - namespace
                             type: object
                           timeout:
+                            format: duration
                             type: string
                           url:
                             type: string
@@ -126,9 +185,34 @@ spec:
                     type: object
                   postUpdateChild:
                     properties:
+                      version:
+                        default: v1
+                        enum:
+                        - v1
+                        - v2
+                        type: string
                       webhook:
                         properties:
+                          etag:
+                            properties:
+                              cacheCleanupSeconds:
+                                format: int32
+                                type: integer
+                              cacheTimeoutSeconds:
+                                format: int32
+                                type: integer
+                              enabled:
+                                type: boolean
+                            type: object
                           path:
+                            type: string
+                          responseUnMarshallMode:
+                            description: Sets the json unmarshall mode. One of the
+                              'loose' or 'strict'. In 'strict' mode additional checks
+                              are performed to detect unknown and duplicated fields.
+                            enum:
+                            - loose
+                            - strict
                             type: string
                           service:
                             properties:
@@ -146,6 +230,7 @@ spec:
                             - namespace
                             type: object
                           timeout:
+                            format: duration
                             type: string
                           url:
                             type: string
@@ -153,9 +238,34 @@ spec:
                     type: object
                   preUpdateChild:
                     properties:
+                      version:
+                        default: v1
+                        enum:
+                        - v1
+                        - v2
+                        type: string
                       webhook:
                         properties:
+                          etag:
+                            properties:
+                              cacheCleanupSeconds:
+                                format: int32
+                                type: integer
+                              cacheTimeoutSeconds:
+                                format: int32
+                                type: integer
+                              enabled:
+                                type: boolean
+                            type: object
                           path:
+                            type: string
+                          responseUnMarshallMode:
+                            description: Sets the json unmarshall mode. One of the
+                              'loose' or 'strict'. In 'strict' mode additional checks
+                              are performed to detect unknown and duplicated fields.
+                            enum:
+                            - loose
+                            - strict
                             type: string
                           service:
                             properties:
@@ -173,6 +283,7 @@ spec:
                             - namespace
                             type: object
                           timeout:
+                            format: duration
                             type: string
                           url:
                             type: string
@@ -180,9 +291,34 @@ spec:
                     type: object
                   sync:
                     properties:
+                      version:
+                        default: v1
+                        enum:
+                        - v1
+                        - v2
+                        type: string
                       webhook:
                         properties:
+                          etag:
+                            properties:
+                              cacheCleanupSeconds:
+                                format: int32
+                                type: integer
+                              cacheTimeoutSeconds:
+                                format: int32
+                                type: integer
+                              enabled:
+                                type: boolean
+                            type: object
                           path:
+                            type: string
+                          responseUnMarshallMode:
+                            description: Sets the json unmarshall mode. One of the
+                              'loose' or 'strict'. In 'strict' mode additional checks
+                              are performed to detect unknown and duplicated fields.
+                            enum:
+                            - loose
+                            - strict
                             type: string
                           service:
                             properties:
@@ -200,6 +336,7 @@ spec:
                             - namespace
                             type: object
                           timeout:
+                            format: duration
                             type: string
                           url:
                             type: string
@@ -210,6 +347,54 @@ spec:
                 properties:
                   apiVersion:
                     type: string
+                  labelSelector:
+                    description: A label selector is a label query over a set of resources.
+                      The result of matchLabels and matchExpressions are ANDed. An
+                      empty label selector matches all objects. A null label selector
+                      matches no objects.
+                    properties:
+                      matchExpressions:
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
+                        items:
+                          description: A label selector requirement is a selector
+                            that contains values, a key, and an operator that relates
+                            the key and values.
+                          properties:
+                            key:
+                              description: key is the label key that the selector
+                                applies to.
+                              type: string
+                            operator:
+                              description: operator represents a key's relationship
+                                to a set of values. Valid operators are In, NotIn,
+                                Exists and DoesNotExist.
+                              type: string
+                            values:
+                              description: values is an array of string values. If
+                                the operator is In or NotIn, the values array must
+                                be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. This array is replaced
+                                during a strategic merge patch.
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: matchLabels is a map of {key,value} pairs. A
+                          single {key,value} in the matchLabels map is equivalent
+                          to an element of matchExpressions, whose key field is "key",
+                          the operator is "In", and the values array contains only
+                          "value". The requirements are ANDed.
+                        type: object
+                    type: object
+                    x-kubernetes-map-type: atomic
                   resource:
                     type: string
                   revisionHistory:
@@ -239,13 +424,6 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -267,6 +445,7 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
+        description: ControllerRevision
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
@@ -295,6 +474,7 @@ spec:
             type: object
           parentPatch:
             type: object
+            x-kubernetes-preserve-unknown-fields: true
         required:
         - metadata
         - parentPatch
@@ -303,13 +483,6 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -334,6 +507,7 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
+        description: DecoratorController
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
@@ -355,6 +529,12 @@ spec:
                     updateStrategy:
                       properties:
                         method:
+                          enum:
+                          - OnDelete
+                          - Recreate
+                          - InPlace
+                          - RollingRecreate
+                          - RollingInPlace
                           type: string
                       type: object
                   required:
@@ -366,9 +546,34 @@ spec:
                 properties:
                   customize:
                     properties:
+                      version:
+                        default: v1
+                        enum:
+                        - v1
+                        - v2
+                        type: string
                       webhook:
                         properties:
+                          etag:
+                            properties:
+                              cacheCleanupSeconds:
+                                format: int32
+                                type: integer
+                              cacheTimeoutSeconds:
+                                format: int32
+                                type: integer
+                              enabled:
+                                type: boolean
+                            type: object
                           path:
+                            type: string
+                          responseUnMarshallMode:
+                            description: Sets the json unmarshall mode. One of the
+                              'loose' or 'strict'. In 'strict' mode additional checks
+                              are performed to detect unknown and duplicated fields.
+                            enum:
+                            - loose
+                            - strict
                             type: string
                           service:
                             properties:
@@ -386,6 +591,7 @@ spec:
                             - namespace
                             type: object
                           timeout:
+                            format: duration
                             type: string
                           url:
                             type: string
@@ -393,9 +599,34 @@ spec:
                     type: object
                   finalize:
                     properties:
+                      version:
+                        default: v1
+                        enum:
+                        - v1
+                        - v2
+                        type: string
                       webhook:
                         properties:
+                          etag:
+                            properties:
+                              cacheCleanupSeconds:
+                                format: int32
+                                type: integer
+                              cacheTimeoutSeconds:
+                                format: int32
+                                type: integer
+                              enabled:
+                                type: boolean
+                            type: object
                           path:
+                            type: string
+                          responseUnMarshallMode:
+                            description: Sets the json unmarshall mode. One of the
+                              'loose' or 'strict'. In 'strict' mode additional checks
+                              are performed to detect unknown and duplicated fields.
+                            enum:
+                            - loose
+                            - strict
                             type: string
                           service:
                             properties:
@@ -413,6 +644,7 @@ spec:
                             - namespace
                             type: object
                           timeout:
+                            format: duration
                             type: string
                           url:
                             type: string
@@ -420,9 +652,34 @@ spec:
                     type: object
                   sync:
                     properties:
+                      version:
+                        default: v1
+                        enum:
+                        - v1
+                        - v2
+                        type: string
                       webhook:
                         properties:
+                          etag:
+                            properties:
+                              cacheCleanupSeconds:
+                                format: int32
+                                type: integer
+                              cacheTimeoutSeconds:
+                                format: int32
+                                type: integer
+                              enabled:
+                                type: boolean
+                            type: object
                           path:
+                            type: string
+                          responseUnMarshallMode:
+                            description: Sets the json unmarshall mode. One of the
+                              'loose' or 'strict'. In 'strict' mode additional checks
+                              are performed to detect unknown and duplicated fields.
+                            enum:
+                            - loose
+                            - strict
                             type: string
                           service:
                             properties:
@@ -440,6 +697,7 @@ spec:
                             - namespace
                             type: object
                           timeout:
+                            format: duration
                             type: string
                           url:
                             type: string
@@ -508,6 +766,7 @@ spec:
                           description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                           type: object
                       type: object
+                      x-kubernetes-map-type: atomic
                     resource:
                       type: string
                   required:
@@ -531,9 +790,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/src/files/manifests/metacontroller.yaml
+++ b/src/files/manifests/metacontroller.yaml
@@ -21,6 +21,14 @@ spec:
       containers:
       - name: metacontroller
         image: {{ metacontroller_image }}
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
         command: ["/usr/bin/metacontroller"]
         args:
         - --zap-log-level=4


### PR DESCRIPTION
Here is the diff file produced by comparing tags `v1.9.0` and `v1.10.0-rc.2` from the `kubeflow/kubeflow` repo:
```
diff -u /home/ubuntu/manifests/apps/pipeline/upstream/third-party/metacontroller/base/old.yaml /home/ubuntu/manifests/apps/pipeline/upstream/third-party/metacontroller/base/new.yaml
--- /home/ubuntu/manifests/apps/pipeline/upstream/third-party/metacontroller/base/old.yaml	2025-03-04 13:53:58.523821268 +0200
+++ /home/ubuntu/manifests/apps/pipeline/upstream/third-party/metacontroller/base/new.yaml	2025-03-04 13:54:13.814625378 +0200
@@ -3,6 +3,7 @@
 metadata:
   annotations:
     api-approved.kubernetes.io: unapproved, request not yet submitted
+    controller-gen.kubebuilder.io/version: v0.13.0
   labels:
     kustomize.component: metacontroller
   name: compositecontrollers.metacontroller.k8s.io
@@ -21,6 +22,7 @@
   - name: v1alpha1
     schema:
       openAPIV3Schema:
+        description: CompositeController
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -46,6 +48,12 @@
                     updateStrategy:
                       properties:
                         method:
+                          enum:
+                          - OnDelete
+                          - Recreate
+                          - InPlace
+                          - RollingRecreate
+                          - RollingInPlace
                           type: string
                         statusChecks:
                           properties:
@@ -75,10 +83,35 @@
                 properties:
                   customize:
                     properties:
+                      version:
+                        default: v1
+                        enum:
+                        - v1
+                        - v2
+                        type: string
                       webhook:
                         properties:
+                          etag:
+                            properties:
+                              cacheCleanupSeconds:
+                                format: int32
+                                type: integer
+                              cacheTimeoutSeconds:
+                                format: int32
+                                type: integer
+                              enabled:
+                                type: boolean
+                            type: object
                           path:
                             type: string
+                          responseUnMarshallMode:
+                            description: Sets the json unmarshall mode. One of the
+                              'loose' or 'strict'. In 'strict' mode additional checks
+                              are performed to detect unknown and duplicated fields.
+                            enum:
+                            - loose
+                            - strict
+                            type: string
                           service:
                             properties:
                               name:
@@ -95,6 +128,7 @@
                             - namespace
                             type: object
                           timeout:
+                            format: duration
                             type: string
                           url:
                             type: string
@@ -102,10 +136,35 @@
                     type: object
                   finalize:
                     properties:
+                      version:
+                        default: v1
+                        enum:
+                        - v1
+                        - v2
+                        type: string
                       webhook:
                         properties:
+                          etag:
+                            properties:
+                              cacheCleanupSeconds:
+                                format: int32
+                                type: integer
+                              cacheTimeoutSeconds:
+                                format: int32
+                                type: integer
+                              enabled:
+                                type: boolean
+                            type: object
                           path:
                             type: string
+                          responseUnMarshallMode:
+                            description: Sets the json unmarshall mode. One of the
+                              'loose' or 'strict'. In 'strict' mode additional checks
+                              are performed to detect unknown and duplicated fields.
+                            enum:
+                            - loose
+                            - strict
+                            type: string
                           service:
                             properties:
                               name:
@@ -122,6 +181,7 @@
                             - namespace
                             type: object
                           timeout:
+                            format: duration
                             type: string
                           url:
                             type: string
@@ -129,10 +189,35 @@
                     type: object
                   postUpdateChild:
                     properties:
+                      version:
+                        default: v1
+                        enum:
+                        - v1
+                        - v2
+                        type: string
                       webhook:
                         properties:
+                          etag:
+                            properties:
+                              cacheCleanupSeconds:
+                                format: int32
+                                type: integer
+                              cacheTimeoutSeconds:
+                                format: int32
+                                type: integer
+                              enabled:
+                                type: boolean
+                            type: object
                           path:
                             type: string
+                          responseUnMarshallMode:
+                            description: Sets the json unmarshall mode. One of the
+                              'loose' or 'strict'. In 'strict' mode additional checks
+                              are performed to detect unknown and duplicated fields.
+                            enum:
+                            - loose
+                            - strict
+                            type: string
                           service:
                             properties:
                               name:
@@ -149,6 +234,7 @@
                             - namespace
                             type: object
                           timeout:
+                            format: duration
                             type: string
                           url:
                             type: string
@@ -156,10 +242,35 @@
                     type: object
                   preUpdateChild:
                     properties:
+                      version:
+                        default: v1
+                        enum:
+                        - v1
+                        - v2
+                        type: string
                       webhook:
                         properties:
+                          etag:
+                            properties:
+                              cacheCleanupSeconds:
+                                format: int32
+                                type: integer
+                              cacheTimeoutSeconds:
+                                format: int32
+                                type: integer
+                              enabled:
+                                type: boolean
+                            type: object
                           path:
                             type: string
+                          responseUnMarshallMode:
+                            description: Sets the json unmarshall mode. One of the
+                              'loose' or 'strict'. In 'strict' mode additional checks
+                              are performed to detect unknown and duplicated fields.
+                            enum:
+                            - loose
+                            - strict
+                            type: string
                           service:
                             properties:
                               name:
@@ -176,6 +287,7 @@
                             - namespace
                             type: object
                           timeout:
+                            format: duration
                             type: string
                           url:
                             type: string
@@ -183,10 +295,35 @@
                     type: object
                   sync:
                     properties:
+                      version:
+                        default: v1
+                        enum:
+                        - v1
+                        - v2
+                        type: string
                       webhook:
                         properties:
+                          etag:
+                            properties:
+                              cacheCleanupSeconds:
+                                format: int32
+                                type: integer
+                              cacheTimeoutSeconds:
+                                format: int32
+                                type: integer
+                              enabled:
+                                type: boolean
+                            type: object
                           path:
                             type: string
+                          responseUnMarshallMode:
+                            description: Sets the json unmarshall mode. One of the
+                              'loose' or 'strict'. In 'strict' mode additional checks
+                              are performed to detect unknown and duplicated fields.
+                            enum:
+                            - loose
+                            - strict
+                            type: string
                           service:
                             properties:
                               name:
@@ -203,6 +340,7 @@
                             - namespace
                             type: object
                           timeout:
+                            format: duration
                             type: string
                           url:
                             type: string
@@ -213,6 +351,54 @@
                 properties:
                   apiVersion:
                     type: string
+                  labelSelector:
+                    description: A label selector is a label query over a set of resources.
+                      The result of matchLabels and matchExpressions are ANDed. An
+                      empty label selector matches all objects. A null label selector
+                      matches no objects.
+                    properties:
+                      matchExpressions:
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
+                        items:
+                          description: A label selector requirement is a selector
+                            that contains values, a key, and an operator that relates
+                            the key and values.
+                          properties:
+                            key:
+                              description: key is the label key that the selector
+                                applies to.
+                              type: string
+                            operator:
+                              description: operator represents a key's relationship
+                                to a set of values. Valid operators are In, NotIn,
+                                Exists and DoesNotExist.
+                              type: string
+                            values:
+                              description: values is an array of string values. If
+                                the operator is In or NotIn, the values array must
+                                be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. This array is replaced
+                                during a strategic merge patch.
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: matchLabels is a map of {key,value} pairs. A
+                          single {key,value} in the matchLabels map is equivalent
+                          to an element of matchExpressions, whose key field is "key",
+                          the operator is "In", and the values array contains only
+                          "value". The requirements are ANDed.
+                        type: object
+                    type: object
+                    x-kubernetes-map-type: atomic
                   resource:
                     type: string
                   revisionHistory:
@@ -242,18 +428,13 @@
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: unapproved, request not yet submitted
+    controller-gen.kubebuilder.io/version: v0.13.0
   labels:
     kustomize.component: metacontroller
   name: controllerrevisions.metacontroller.k8s.io
@@ -269,6 +450,7 @@
   - name: v1alpha1
     schema:
       openAPIV3Schema:
+        description: ControllerRevision
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -301,6 +483,7 @@
             type: object
           parentPatch:
             type: object
+            x-kubernetes-preserve-unknown-fields: true
         required:
         - metadata
         - parentPatch
@@ -309,18 +492,13 @@
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: unapproved, request not yet submitted
+    controller-gen.kubebuilder.io/version: v0.13.0
   labels:
     kustomize.component: metacontroller
   name: decoratorcontrollers.metacontroller.k8s.io
@@ -339,6 +517,7 @@
   - name: v1alpha1
     schema:
       openAPIV3Schema:
+        description: DecoratorController
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -364,6 +543,12 @@
                     updateStrategy:
                       properties:
                         method:
+                          enum:
+                          - OnDelete
+                          - Recreate
+                          - InPlace
+                          - RollingRecreate
+                          - RollingInPlace
                           type: string
                       type: object
                   required:
@@ -375,10 +560,35 @@
                 properties:
                   customize:
                     properties:
+                      version:
+                        default: v1
+                        enum:
+                        - v1
+                        - v2
+                        type: string
                       webhook:
                         properties:
+                          etag:
+                            properties:
+                              cacheCleanupSeconds:
+                                format: int32
+                                type: integer
+                              cacheTimeoutSeconds:
+                                format: int32
+                                type: integer
+                              enabled:
+                                type: boolean
+                            type: object
                           path:
                             type: string
+                          responseUnMarshallMode:
+                            description: Sets the json unmarshall mode. One of the
+                              'loose' or 'strict'. In 'strict' mode additional checks
+                              are performed to detect unknown and duplicated fields.
+                            enum:
+                            - loose
+                            - strict
+                            type: string
                           service:
                             properties:
                               name:
@@ -395,6 +605,7 @@
                             - namespace
                             type: object
                           timeout:
+                            format: duration
                             type: string
                           url:
                             type: string
@@ -402,10 +613,35 @@
                     type: object
                   finalize:
                     properties:
+                      version:
+                        default: v1
+                        enum:
+                        - v1
+                        - v2
+                        type: string
                       webhook:
                         properties:
+                          etag:
+                            properties:
+                              cacheCleanupSeconds:
+                                format: int32
+                                type: integer
+                              cacheTimeoutSeconds:
+                                format: int32
+                                type: integer
+                              enabled:
+                                type: boolean
+                            type: object
                           path:
                             type: string
+                          responseUnMarshallMode:
+                            description: Sets the json unmarshall mode. One of the
+                              'loose' or 'strict'. In 'strict' mode additional checks
+                              are performed to detect unknown and duplicated fields.
+                            enum:
+                            - loose
+                            - strict
+                            type: string
                           service:
                             properties:
                               name:
@@ -422,6 +658,7 @@
                             - namespace
                             type: object
                           timeout:
+                            format: duration
                             type: string
                           url:
                             type: string
@@ -429,10 +666,35 @@
                     type: object
                   sync:
                     properties:
+                      version:
+                        default: v1
+                        enum:
+                        - v1
+                        - v2
+                        type: string
                       webhook:
                         properties:
+                          etag:
+                            properties:
+                              cacheCleanupSeconds:
+                                format: int32
+                                type: integer
+                              cacheTimeoutSeconds:
+                                format: int32
+                                type: integer
+                              enabled:
+                                type: boolean
+                            type: object
                           path:
                             type: string
+                          responseUnMarshallMode:
+                            description: Sets the json unmarshall mode. One of the
+                              'loose' or 'strict'. In 'strict' mode additional checks
+                              are performed to detect unknown and duplicated fields.
+                            enum:
+                            - loose
+                            - strict
+                            type: string
                           service:
                             properties:
                               name:
@@ -449,6 +711,7 @@
                             - namespace
                             type: object
                           timeout:
+                            format: duration
                             type: string
                           url:
                             type: string
@@ -543,6 +806,7 @@
                             only "value". The requirements are ANDed.
                           type: object
                       type: object
+                      x-kubernetes-map-type: atomic
                     resource:
                       type: string
                   required:
@@ -566,12 +830,6 @@
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -582,6 +840,111 @@
   namespace: kubeflow
 ---
 apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    kustomize.component: metacontroller
+  name: kubeflow-metacontroller
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - namespaces/status
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - networking.istio.io
+  resources:
+  - destinationrules
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - security.istio.io
+  resources:
+  - authorizationpolicies
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - metacontroller.k8s.io
+  resources:
+  - compositecontrollers
+  - controllerrevisions
+  - decoratorcontrollers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
@@ -590,7 +953,7 @@
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: cluster-admin
+  name: kubeflow-metacontroller
 subjects:
 - kind: ServiceAccount
   name: meta-controller-service
@@ -620,12 +983,21 @@
         kustomize.component: metacontroller
     spec:
       containers:
-      - command:
-        - /usr/bin/metacontroller
+      - args:
         - --zap-log-level=4
         - --discovery-interval=3600s
-        image: docker.io/metacontrollerio/metacontroller:v2.0.4
+        command:
+        - /usr/bin/metacontroller
+        image: ghcr.io/metacontroller/metacontroller:v4.11.22
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
         name: metacontroller
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
         resources:
           limits:
             cpu: "1"
@@ -642,5 +1014,7 @@
           readOnlyRootFilesystem: true
           runAsNonRoot: true
           runAsUser: 1000
+          seccompProfile:
+            type: RuntimeDefault
       serviceAccountName: meta-controller-service
   volumeClaimTemplates: []

Diff finished.  Tue Mar  4 13:54:39 2025

```