### PR TITLE
fix: include necessary RBAC

### DIFF
--- a/src/files/manifests/metacontroller-rbac.yaml
+++ b/src/files/manifests/metacontroller-rbac.yaml
@@ -14,6 +14,18 @@ metadata:
   name: {{ namespace }}-{{ app_name }}-charm
 rules:
 - apiGroups:
+  - kubeflow.org
+  resources:
+  - poddefaults  # needed for resource dispatcher
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - create
+  - patch
+  - delete
+- apiGroups:
   - ""
   resources:
   - namespaces
@@ -35,7 +47,8 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - secrets
+  - secrets          # needed for resource dispatcher
+  - serviceaccounts  # needed for resource dispatcher
   - configmaps
   verbs:
   - get

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -16,12 +16,23 @@ from pytest_operator.plugin import OpsTest
 
 logger = logging.getLogger(__name__)
 
+ADMISSION_WEBHOOK = "admission-webhook"
+ADMISSION_WEBHOOK_CHANNEL = "latest/edge"
+ADMISSION_WEBHOOK_TRUST = True
+
 METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
 APP_NAME = "metacontroller-operator"
 
 
 @pytest.mark.abort_on_fail
 async def test_build_and_deploy_with_trust(ops_test: OpsTest):
+    # Deploy the Admission Webhook, to ensure PodDefault CRs are installed
+    await ops_test.model.deploy(
+        entity_url=ADMISSION_WEBHOOK,
+        channel=ADMISSION_WEBHOOK_CHANNEL,
+        trust=ADMISSION_WEBHOOK_TRUST,
+    )
+
     logger.info("Building charm")
     built_charm_path = await ops_test.build_charm("./")
     logger.info(f"Built charm {built_charm_path}")
@@ -39,6 +50,7 @@ async def test_build_and_deploy_with_trust(ops_test: OpsTest):
         resources=resources,
         trust=True,
     )
+    await ops_test.model.wait_for_idle(apps=[ADMISSION_WEBHOOK], status="active", timeout=60 * 15)
 
     apps = [APP_NAME]
     await ops_test.model.wait_for_idle(
@@ -73,6 +85,28 @@ async def test_alert_rules(ops_test):
     alert_rules = get_alert_rules()
     logger.info("found alert_rules: %s", alert_rules)
     await assert_alert_rules(app, alert_rules)
+
+
+async def test_authorization_for_creating_resources(ops_test: OpsTest):
+    """Assert Metacontroller can create PodDefaults, Secrets and ServiceAccounts."""
+    logger.info("Checking with `kubectl auth can-i create`")
+
+    # Needed for Resource Dispatcher
+    resources = ["secrets", "serviceaccounts", "poddefaults"]
+    namespace = ops_test.model_name
+
+    for resource in resources:
+        _, stdout, _ = await ops_test.run(
+            "kubectl",
+            "auth",
+            "can-i",
+            "create",
+            f"{resource}",
+            f"--as=system:serviceaccount:{namespace}:{APP_NAME}-charm",
+            check=True,
+            fail_msg="Failed to execute kubectl auth",
+        )
+        assert stdout.strip() == "yes"
 
 
 # TODO: Add test for charm removal


### PR DESCRIPTION
Closes https://github.com/canonical/metacontroller-operator/issues/157
## Changes
1. Added RBAC permissions for ServiceAccounts and PodDefaults
2. Added small comments in those resources, so it's easier to detect we need them, so we don't accidentally delete them in the future
## Review Notes
I tested the changes manually by:
1. Spinning up the `latest` bundle with
    ```bash
    # bundle-kubeflow repo
    tox -vve test_bundle_deployment-latest -- --model kubeflow --keep-models -vv -s
    ```
2. Packed and deployhed the charm from this PR

The KFP PodDefault was there. I also deployed MLflow and related with KServe as well, and all Secrets, PodDefaults and ServiceAccounts were created as expected.

```bash
# kubectl -n admin get secrets
NAME                                 TYPE     DATA   AGE
kserve-controller-s3                 Opaque   2      17m
mlflow-server-minio-artifact         Opaque   2      10m
mlflow-server-seldon-rclone-secret   Opaque   6      10m
mlpipeline-minio-artifact            Opaque   2      23m

# kubectl -n admin get poddefaults.kubeflow.org
NAME                         AGE
access-ml-pipeline           21m
mlflow-server-access-minio   10m
mlflow-server-minio

# kubectl -n admin get serviceaccounts
NAME                   SECRETS   AGE
default                0         24m
default-editor         0         24m
default-viewer         0         24m
kserve-controller-s3   1         18m
```