### PR TITLE
chore: Update `charmed_kubeflow_chisme` in requirements

### DIFF
--- a/requirements-integration.in
+++ b/requirements-integration.in
@@ -7,6 +7,6 @@ pytest-operator
 pyyaml
 requests
 tenacity
-# Pin to >=0.4.0 because the reusable test infrastructure is on that version and above
-# This prevents pip-compile from trying to pin an earlier version
-charmed-kubeflow-chisme>=0.4.0
+# "charmed-kubeflow-chisme" pinned to avoid closed "latest" tracks with COS charms, see:
+# https://github.com/canonical/charmed-kubeflow-chisme/issues/155
+charmed-kubeflow-chisme>=0.4.11

--- a/requirements-integration.txt
+++ b/requirements-integration.txt
@@ -34,7 +34,7 @@ cffi==1.17.1
     # via
     #   cryptography
     #   pynacl
-charmed-kubeflow-chisme==0.4.9
+charmed-kubeflow-chisme==0.4.11
     # via -r requirements-integration.in
 charset-normalizer==3.4.0
     # via requests


### PR DESCRIPTION
This PR updates `charmed_kubeflow_chisme` to fix https://github.com/canonical/charmed-kubeflow-chisme/issues/155